### PR TITLE
ci: bump softprops/action-gh-release v2 -> v3 (Node 24) [JUN-1042]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create GitHub Release (auto notes)
         if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ inputs.version }}
           name: v${{ inputs.version }}


### PR DESCRIPTION
## Summary

Single-line bump of \`softprops/action-gh-release@v2\` → \`@v3\` to move off the deprecated Node.js 20 JS runtime ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

Same change was validated end-to-end on [junovy-money#56](https://github.com/Junovy-Hosting/junovy-money/pull/56).

Tracking: [JUN-1042](https://linear.app/junovy/issue/JUN-1042)

## Test plan

- [ ] Bugbot pass
- [ ] Next \`workflow_dispatch\` (or release-published) run is green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that upgrades the GitHub Release action; impact is limited to the release workflow behavior on GitHub Actions runs.
> 
> **Overview**
> Updates the release workflow to use `softprops/action-gh-release@v3` instead of `@v2` when creating GitHub Releases during `workflow_dispatch`, aligning with newer GitHub Actions runtimes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec8dd5669950f791201d8da0737ae23529a5684. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->